### PR TITLE
feat: add ecs-and-deepseek-build-personal-website solution

### DIFF
--- a/solution/tech-solution/ecs-and-deepseek-build-personal-website/README.md
+++ b/solution/tech-solution/ecs-and-deepseek-build-personal-website/README.md
@@ -1,0 +1,46 @@
+<!-- DOCS_DESCRIPTION_CN -->
+本示例用于实现解决方案[低成本搭建 DeepSeek 专属 AI 网站](https://www.aliyun.com/solution/tech-solution/ecs-and-deepseek-build-personal-website), 涉及到专有网络（VPC）、交换机（VSwitch）、云服务器（ECS）、RAM 用户等资源的创建。
+<!-- DOCS_DESCRIPTION_CN -->
+
+<!-- DOCS_DESCRIPTION_EN -->
+This example is used to implement solution [ECS and Deepseek Build Personal Website](https://www.aliyun.com/solution/tech-solution/ecs-and-deepseek-build-personal-website), which involves the creation and deployment of resources such as Virtual Private Cloud (VPC), VSwitch, Elastic Compute Service (ECS), and RAM users.
+<!-- DOCS_DESCRIPTION_EN --
+
+<!-- BEGIN_TF_DOCS -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_alicloud"></a> [alicloud](#provider\_alicloud) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [alicloud_ecs_command.install_app](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ecs_command) | resource |
+| [alicloud_ecs_invocation.invoke_script](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ecs_invocation) | resource |
+| [alicloud_instance.ecs_instance](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/instance) | resource |
+| [alicloud_ram_user.user](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/ram_user) | resource |
+| [alicloud_security_group.security_group](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/security_group) | resource |
+| [alicloud_security_group_rule.allow_tcp_8080](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/security_group_rule) | resource |
+| [alicloud_vpc.vpc](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/vpc) | resource |
+| [alicloud_vswitch.vswitch](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/vswitch) | resource |
+| [random_id.suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [alicloud_regions.current](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/regions) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_CommonName"></a> [CommonName](#input\_CommonName) | n/a | `string` | `"deepseek-private-ai"` | no |
+| <a name="input_InstanceType"></a> [InstanceType](#input\_InstanceType) | {<br/>    "AssociationProperty": "ALIYUN::ECS::Instance::InstanceType",<br/>    "AssociationPropertyMetadata": {<br/>      "ZoneId": "${ZoneId}",<br/>      "InstanceChargeType": "PostPaid",<br/>      "SystemDiskCategory": "cloud\_essd",<br/>      "Constraints": {<br/>        "Architecture": ["X86"],<br/>        "vCPU": [2],<br/>        "Memory": [2]<br/>      }<br/>    },<br/>    "Label": {<br/>      "zh-cn": "实例类型",<br/>      "en": "Instance Type"<br/>    }<br/>  } | `string` | `"ecs.e-c1m1.large"` | no |
+| <a name="input_ZoneId"></a> [ZoneId](#input\_ZoneId) | {<br/>    "AssociationProperty": "ALIYUN::ECS::Instance::ZoneId",<br/>    "Description": {<br/>      "zh-cn": "可用区",<br/>      "en": "Availability Zone"<br/>    },<br/>    "Label": {<br/>      "zh-cn": "可用区",<br/>      "en": "Availability Zone"<br/>    }<br/>  } | `string` | `"cn-hangzhou-f"` | no |
+| <a name="input_bai_lian_api_key"></a> [bai\_lian\_api\_key](#input\_bai\_lian\_api\_key) | 百炼 API-KEY，需开通百炼模型服务再获取 API-KEY，详情请参考：https://help.aliyun.com/zh/model-studio/developer-reference/get-api-key | `string` | n/a | yes |
+| <a name="input_ecs_instance_password"></a> [ecs\_instance\_password](#input\_ecs\_instance\_password) | 服务器登录密码,长度8-30，必须包含三项（大写字母、小写字母、数字、 ()`~!@#$%^&*_-+=|{}[]:;'<>,.?/ 中的特殊符号）` | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | 地域，例如：cn-hangzhou。所有地域及可用区请参见文档：https://help.aliyun.com/document_detail/40654.html#09f1dc16b0uke | `string` | `"cn-hangzhou"` | no |
+<!-- END_TF_DOCS -->

--- a/solution/tech-solution/ecs-and-deepseek-build-personal-website/main.tf
+++ b/solution/tech-solution/ecs-and-deepseek-build-personal-website/main.tf
@@ -1,0 +1,80 @@
+provider "alicloud" {
+  region = var.region
+}
+
+resource "random_id" "suffix" {
+  byte_length = 8
+}
+
+locals {
+  common_name = "${var.CommonName}-${random_id.suffix.hex}"
+}
+
+resource "alicloud_vpc" "vpc" {
+  cidr_block = "192.168.0.0/16"
+  vpc_name   = "${local.common_name}-vpc"
+}
+
+resource "alicloud_vswitch" "vswitch" {
+  vpc_id       = alicloud_vpc.vpc.id
+  cidr_block   = "192.168.0.0/24"
+  zone_id      = var.ZoneId
+  vswitch_name = "${local.common_name}-vsw"
+}
+
+resource "alicloud_security_group" "security_group" {
+  vpc_id              = alicloud_vpc.vpc.id
+  security_group_name = "${local.common_name}-sg"
+}
+
+resource "alicloud_security_group_rule" "allow_tcp_8080" {
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = "8080/8080"
+  priority          = 1
+  security_group_id = alicloud_security_group.security_group.id
+  cidr_ip           = "0.0.0.0/0"
+}
+
+resource "alicloud_instance" "ecs_instance" {
+  instance_name              = "${local.common_name}-ecs"
+  system_disk_category       = "cloud_essd"
+  image_id                   = "aliyun_3_x64_20G_alibase_20250117.vhd"
+  vswitch_id                 = alicloud_vswitch.vswitch.id
+  password                   = var.ecs_instance_password
+  instance_type              = var.InstanceType
+  internet_max_bandwidth_out = 10
+  security_groups            = [alicloud_security_group.security_group.id]
+}
+
+resource "alicloud_ram_user" "user" {
+  name = "create_by_solution-${local.common_name}"
+}
+
+resource "alicloud_ecs_command" "install_app" {
+  name = "install-deepseek-app"
+  command_content = base64encode(<<EOF
+    #!/bin/bash
+    cat <<EOT >> ~/.bash_profile
+    export API_KEY="${var.bai_lian_api_key}"
+    export ROS_DEPLOY=true
+    EOT
+
+    source ~/.bash_profile 
+    curl -fsSL https://static-aliyun-doc.oss-cn-hangzhou.aliyuncs.com/install-script/deepseek-r1-private/install.sh|bash
+    EOF
+  )
+  working_dir = "/root"
+  type        = "RunShellScript"
+  timeout     = 3600
+}
+
+resource "alicloud_ecs_invocation" "invoke_script" {
+  instance_id = [alicloud_instance.ecs_instance.id]
+  command_id  = alicloud_ecs_command.install_app.id
+  timeouts {
+    create = "15m"
+  }
+}

--- a/solution/tech-solution/ecs-and-deepseek-build-personal-website/outputs.tf
+++ b/solution/tech-solution/ecs-and-deepseek-build-personal-website/outputs.tf
@@ -1,0 +1,32 @@
+output "ecs_login_address" {
+  description = <<EOT
+  {
+    "Description": {
+      "en": "Ecs login address.",
+      "zh-cn": "ECS登录地址。"
+    }
+  }
+  EOT
+  value       = "https://ecs-workbench.aliyun.com/?from=EcsConsole&instanceType=ecs&regionId=${data.alicloud_regions.current.id}&instanceId=${alicloud_instance.ecs_instance.id}"
+}
+
+output "demo_url" {
+  description = <<EOT
+  {
+    "Label": {
+      "zh-cn": "体验地址",
+      "en": "Experience Addresses"
+    },
+    "Description": {
+      "en": "Experience address.",
+      "zh-cn": "体验地址。"
+    }
+  }
+  EOT
+  value       = "http://${alicloud_instance.ecs_instance.public_ip}:8080"
+}
+
+# 获取当前区域信息的数据源
+data "alicloud_regions" "current" {
+  current = true
+}

--- a/solution/tech-solution/ecs-and-deepseek-build-personal-website/variables.tf
+++ b/solution/tech-solution/ecs-and-deepseek-build-personal-website/variables.tf
@@ -1,0 +1,63 @@
+variable "region" {
+  type        = string
+  default     = "cn-hangzhou"
+  description = "地域，例如：cn-hangzhou。所有地域及可用区请参见文档：https://help.aliyun.com/document_detail/40654.html#09f1dc16b0uke"
+}
+
+variable "ZoneId" {
+  type        = string
+  default     = "cn-hangzhou-f"
+  description = <<EOT
+  {
+    "AssociationProperty": "ALIYUN::ECS::Instance::ZoneId",
+    "Description": {
+      "zh-cn": "可用区",
+      "en": "Availability Zone"
+    },
+    "Label": {
+      "zh-cn": "可用区",
+      "en": "Availability Zone"
+    }
+  }
+  EOT
+}
+
+variable "InstanceType" {
+  type        = string
+  default     = "ecs.e-c1m1.large"
+  description = <<EOT
+  {
+    "AssociationProperty": "ALIYUN::ECS::Instance::InstanceType",
+    "AssociationPropertyMetadata": {
+      "ZoneId": "$${ZoneId}",
+      "InstanceChargeType": "PostPaid",
+      "SystemDiskCategory": "cloud_essd",
+      "Constraints": {
+        "Architecture": ["X86"],
+        "vCPU": [2],
+        "Memory": [2]
+      }
+    },
+    "Label": {
+      "zh-cn": "实例类型",
+      "en": "Instance Type"
+    }
+  }
+  EOT
+}
+
+variable "ecs_instance_password" {
+  type        = string
+  sensitive   = true
+  description = "服务器登录密码,长度8-30，必须包含三项（大写字母、小写字母、数字、 ()`~!@#$%^&*_-+=|{}[]:;'<>,.?/ 中的特殊符号）"
+}
+
+variable "bai_lian_api_key" {
+  type        = string
+  description = "百炼 API-KEY，需开通百炼模型服务再获取 API-KEY，详情请参考：https://help.aliyun.com/zh/model-studio/developer-reference/get-api-key"
+}
+
+variable "CommonName" {
+  type    = string
+  default = "deepseek-private-ai"
+}


### PR DESCRIPTION
- Add Terraform templates for ECS and DeepSeek personal website
- Include VPC, VSwitch, ECS instance, security groups
- Add DeepSeek AI application installation script
- Generate comprehensive README documentation
- Format all Terraform files with terraform fmt